### PR TITLE
Treat the "i586" perf traces as "x86"

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -264,7 +264,10 @@ int main(int argc, char *argv[])
             }
         }
 
-        const QByteArray &featureArch = features.architecture();
+        auto featureArch = features.architecture();
+        if (featureArch == "i586") {
+            featureArch = "x86";
+        }
         for (uint i = 0; i < PerfRegisterInfo::ARCH_INVALID; ++i) {
             if (featureArch.startsWith(PerfRegisterInfo::s_archNames[i])) {
                 unwind.setArchitecture(static_cast<PerfRegisterInfo::Architecture>(i));

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -230,7 +230,8 @@ int main(int argc, char *argv[])
                       parser.value(extra), parser.value(appPath), parser.isSet(kallsymsPath)
                         ? parser.value(kallsymsPath)
                         : parser.value(sysroot) + parser.value(kallsymsPath),
-                      parser.isSet(printStats), maxEventBufferSize, maxFramesValue);
+                      parser.isSet(kallsymsPath), parser.isSet(printStats),
+                      maxEventBufferSize, maxFramesValue);
 
     PerfHeader header(infile.data());
     PerfAttributes attributes;

--- a/app/perfattributes.cpp
+++ b/app/perfattributes.cpp
@@ -279,7 +279,7 @@ bool PerfAttributes::read(QIODevice *device, PerfHeader *header)
             }
 
             QDataStream idStream(device);
-            stream.setByteOrder(header->byteOrder());
+            idStream.setByteOrder(header->byteOrder());
             quint64 id;
             for (uint i = 0; i < ids.size / sizeof(quint64); ++i) {
                 idStream >> id;

--- a/app/perfattributes.h
+++ b/app/perfattributes.h
@@ -40,6 +40,8 @@ public:
     quint32 type() const { return m_type; }
     quint64 config() const { return m_config; }
     int sampleIdOffset() const;
+    bool usesFrequency() const { return m_freq; };
+    quint64 frequenyOrPeriod() const { return m_sampleFreq; }
 
     QByteArray name() const;
 

--- a/app/perfdata.cpp
+++ b/app/perfdata.cpp
@@ -488,7 +488,7 @@ QDataStream &operator>>(QDataStream &stream, PerfRecordSample &record)
         quint64 numIps;
         quint64 ip;
         stream >> numIps;
-        while (numIps-- > 0) {
+        while (numIps && numIps-- > 0) {
             stream >> ip;
             record.m_callchain << ip;
         }

--- a/app/perfelfmap.cpp
+++ b/app/perfelfmap.cpp
@@ -26,7 +26,7 @@
 QDebug operator<<(QDebug stream, const PerfElfMap::ElfInfo& info)
 {
     stream.nospace() << "ElfInfo{"
-                     << "localFile=" << info.localFile.fileName() << ", "
+                     << "localFile=" << info.localFile.absoluteFilePath() << ", "
                      << "isFile=" << info.isFile() << ", "
                      << "originalFileName=" << info.originalFileName << ", "
                      << "originalPath=" << info.originalPath << ", "

--- a/app/perfelfmap.cpp
+++ b/app/perfelfmap.cpp
@@ -29,6 +29,7 @@ QDebug operator<<(QDebug stream, const PerfElfMap::ElfInfo& info)
                      << "localFile=" << info.localFile.fileName() << ", "
                      << "isFile=" << info.isFile() << ", "
                      << "originalFileName=" << info.originalFileName << ", "
+                     << "originalPath=" << info.originalPath << ", "
                      << "addr=" << info.addr << ", "
                      << "len=" << info.length << ", "
                      << "pgoff=" << info.pgoff << ", "
@@ -52,7 +53,8 @@ struct SortByAddr
 }
 
 bool PerfElfMap::registerElf(const quint64 addr, const quint64 len, quint64 pgoff,
-                             const QFileInfo &fullPath, const QByteArray &originalFileName)
+                             const QFileInfo &fullPath, const QByteArray &originalFileName,
+                             const QByteArray &originalPath)
 {
     bool cacheInvalid = false;
     const quint64 addrEnd = addr + len;
@@ -69,12 +71,13 @@ bool PerfElfMap::registerElf(const quint64 addr, const quint64 len, quint64 pgof
         // reinsert any fragments of it that remain.
 
         if (i->addr < addr) {
-            newElfs.push_back(ElfInfo(i->localFile, i->addr, addr - i->addr,
-                                      i->pgoff, i->originalFileName));
+            newElfs.push_back(ElfInfo(i->localFile, i->addr, addr - i->addr, i->pgoff,
+                                      i->originalFileName, i->originalPath));
         }
         if (iEnd > addrEnd) {
             newElfs.push_back(ElfInfo(i->localFile, addrEnd, iEnd - addrEnd,
-                                      i->pgoff + addrEnd - i->addr, i->originalFileName));
+                                      i->pgoff + addrEnd - i->addr,
+                                      i->originalFileName, i->originalPath));
         }
 
         removedElfs.push_back(std::distance(m_elfs.begin(), i));
@@ -90,7 +93,7 @@ bool PerfElfMap::registerElf(const quint64 addr, const quint64 len, quint64 pgof
     for (auto it = removedElfs.rbegin(), end = removedElfs.rend(); it != end; ++it)
         m_elfs.remove(*it);
 
-    newElfs.push_back(ElfInfo(fullPath, addr, len, pgoff, originalFileName));
+    newElfs.push_back(ElfInfo(fullPath, addr, len, pgoff, originalFileName, originalPath));
 
     for (const auto &elf : newElfs) {
         auto it = std::lower_bound(m_elfs.begin(), m_elfs.end(),

--- a/app/perfelfmap.h
+++ b/app/perfelfmap.h
@@ -30,11 +30,15 @@ public:
     struct ElfInfo {
         explicit ElfInfo(const QFileInfo &localFile = QFileInfo(), quint64 addr = 0,
                          quint64 length = 0, quint64 pgoff = 0,
-                         const QByteArray &originalFileName = {}) :
+                         const QByteArray &originalFileName = {},
+                         const QByteArray &originalPath = {}) :
             localFile(localFile),
             originalFileName(originalFileName.isEmpty()
                 ? localFile.fileName().toLocal8Bit()
                 : originalFileName),
+            originalPath(originalPath.isEmpty()
+                ? localFile.absoluteFilePath().toLocal8Bit()
+                : originalPath),
             addr(addr), length(length), pgoff(pgoff)
         {}
 
@@ -53,6 +57,7 @@ public:
             return isFile() == rhs.isFile()
                 && (!isFile() || localFile == rhs.localFile)
                 && originalFileName == rhs.originalFileName
+                && originalPath == rhs.originalPath
                 && addr == rhs.addr
                 && length == rhs.length
                 && pgoff == rhs.pgoff;
@@ -60,13 +65,16 @@ public:
 
         QFileInfo localFile;
         QByteArray originalFileName;
+        QByteArray originalPath;
         quint64 addr;
         quint64 length;
         quint64 pgoff;
     };
 
     bool registerElf(quint64 addr, quint64 len, quint64 pgoff,
-                     const QFileInfo &fullPath, const QByteArray &originalFileName = {});
+                     const QFileInfo &fullPath,
+                     const QByteArray &originalFileName = {},
+                     const QByteArray &originalPath = {});
     ElfInfo findElf(quint64 ip) const;
 
     bool isEmpty() const

--- a/app/perffeatures.cpp
+++ b/app/perffeatures.cpp
@@ -215,7 +215,7 @@ QDataStream &operator>>(QDataStream &stream, PerfCmdline &cmdline)
     quint32 numParts;
     stream >> numParts;
     PerfStringFeature stringFeature;
-    while (numParts-- > 0) {
+    while (numParts && numParts-- > 0) {
         stream >> stringFeature;
         cmdline.cmdline << stringFeature.value;
     }
@@ -230,14 +230,14 @@ QDataStream &operator>>(QDataStream &stream, PerfEventDesc &eventDesc)
     quint64 id;
     stream >> numEvents >> eventSize;
     PerfStringFeature stringFeature;
-    while (numEvents-- > 0) {
+    while (numEvents && numEvents-- > 0) {
         eventDesc.eventDescs << PerfEventDesc::EventDesc();
         PerfEventDesc::EventDesc &currentEvent = eventDesc.eventDescs.last();
         stream >> currentEvent.attrs;
         stream >> numIds;
         stream >> stringFeature;
         currentEvent.name = stringFeature.value;
-        while (numIds-- > 0) {
+        while (numIds && numIds-- > 0) {
             stream >> id;
             currentEvent.ids << id;
         }
@@ -254,13 +254,13 @@ QDataStream &operator>>(QDataStream &stream, PerfCpuTopology &cpuTopology)
     PerfStringFeature stringFeature;
     stream >> numSiblings;
 
-    while (numSiblings-- > 0) {
+    while (numSiblings && numSiblings-- > 0) {
         stream >> stringFeature;
         cpuTopology.siblingCores << stringFeature.value;
     }
 
     stream >> numSiblings;
-    while (numSiblings-- > 0) {
+    while (numSiblings && numSiblings-- > 0) {
         stream >> stringFeature;
         cpuTopology.siblingThreads << stringFeature.value;
     }
@@ -278,7 +278,7 @@ QDataStream &operator>>(QDataStream &stream, PerfNumaTopology &numaTopology)
     stream >> numNodes;
 
     PerfStringFeature stringFeature;
-    while (numNodes-- > 0) {
+    while (numNodes && numNodes-- > 0) {
         PerfNumaTopology::NumaNode node;
         stream >> node.nodeId >> node.memTotal >> node.memFree >> stringFeature;
         node.topology = stringFeature.value;
@@ -317,7 +317,7 @@ QDataStream &operator>>(QDataStream &stream, PerfPmuMappings &pmuMappings)
     stream >> numPmus;
 
     PerfStringFeature stringFeature;
-    while (numPmus-- > 0) {
+    while (numPmus && numPmus-- > 0) {
         PerfPmuMappings::Pmu pmu;
         stream >> pmu.type >> stringFeature;
         pmu.name = stringFeature.value;
@@ -342,7 +342,7 @@ QDataStream &operator>>(QDataStream &stream, PerfGroupDesc &groupDesc)
     stream >> numGroups;
 
     PerfStringFeature stringFeature;
-    while (numGroups-- > 0) {
+    while (numGroups && numGroups-- > 0) {
         PerfGroupDesc::GroupDesc desc;
         stream >> stringFeature;
         desc.name = stringFeature.value;

--- a/app/perfkallsyms.h
+++ b/app/perfkallsyms.h
@@ -41,6 +41,7 @@ class PerfKallsyms
 public:
     bool parseMapping(const QString &path);
     QString errorString() const { return m_errorString; }
+    bool isEmpty() const { return m_entries.isEmpty(); }
 
     PerfKallsymEntry findEntry(quint64 address) const;
 

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -287,7 +287,8 @@ void PerfSymbolTable::registerElf(const PerfRecordMmap &mmap, const QByteArray &
     QLatin1String filePath(mmap.filename());
     // special regions, such as [heap], [vdso], [stack], ... as well as //anon
     const bool isSpecialRegion = (mmap.filename().startsWith('[') && mmap.filename().endsWith(']'))
-                              || filePath == QLatin1String("//anon");
+                              || filePath == QLatin1String("//anon")
+                              || filePath == QLatin1String("/SYSV00000000 (deleted)");
     const auto fileName = QFileInfo(filePath).fileName();
     QFileInfo fullPath;
     if (isSpecialRegion) {

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -141,7 +141,7 @@ static bool memoryRead(Dwfl *dwfl, Dwarf_Addr addr, Dwarf_Word *result, void *ar
 
     /* Check overflow. */
     if (addr > std::numeric_limits<Dwarf_Addr>::max() - sizeof(Dwarf_Word)) {
-        qWarning() << "Invalid memory read requested by dwfl" << addr;
+        qDebug() << "Invalid memory read requested by dwfl" << addr;
         ui->firstGuessedFrame = ui->frames.length();
         return false;
     }

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -146,7 +146,7 @@ static bool memoryRead(Dwfl *dwfl, Dwarf_Addr addr, Dwarf_Word *result, void *ar
             PerfRegisterInfo::s_wordWidth[ui->unwind->architecture()][registerAbi(ui->sample)];
 
     /* Check overflow. */
-    if (addr + sizeof(Dwarf_Word) < addr) {
+    if (addr > std::numeric_limits<Dwarf_Addr>::max() - sizeof(Dwarf_Word)) {
         qWarning() << "Invalid memory read requested by dwfl" << addr;
         ui->firstGuessedFrame = ui->frames.length();
         return false;

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -553,6 +553,77 @@ PerfElfMap::ElfInfo PerfSymbolTable::findElf(quint64 ip) const
     return m_elfs.findElf(ip);
 }
 
+// based on MIT licensed https://github.com/bombela/backward-cpp
+static bool die_has_pc(Dwarf_Die* die, Dwarf_Addr pc)
+{
+    Dwarf_Addr low, high;
+
+    // continuous range
+    if (dwarf_hasattr(die, DW_AT_low_pc) && dwarf_hasattr(die, DW_AT_high_pc)) {
+        if (dwarf_lowpc(die, &low) != 0)
+            return false;
+        if (dwarf_highpc(die, &high) != 0) {
+            Dwarf_Attribute attr_mem;
+            Dwarf_Attribute* attr = dwarf_attr(die, DW_AT_high_pc, &attr_mem);
+            Dwarf_Word value;
+            if (dwarf_formudata(attr, &value) != 0)
+                return false;
+            high = low + value;
+        }
+        return pc >= low && pc < high;
+    }
+
+    // non-continuous range.
+    Dwarf_Addr base;
+    ptrdiff_t offset = 0;
+    while ((offset = dwarf_ranges(die, offset, &base, &low, &high)) > 0) {
+        if (pc >= low && pc < high)
+            return true;
+    }
+    return false;
+}
+
+static bool find_fundie_by_pc(Dwarf_Die* parent_die, Dwarf_Addr pc)
+{
+    Dwarf_Die die;
+    if (dwarf_child(parent_die, &die) != 0)
+        return false;
+
+    do {
+        switch (dwarf_tag(&die)) {
+        case DW_TAG_subprogram:
+        case DW_TAG_inlined_subroutine:
+            if (die_has_pc(&die, pc))
+                return true;
+        };
+        bool declaration = false;
+        Dwarf_Attribute attr_mem;
+        dwarf_formflag(dwarf_attr(&die, DW_AT_declaration, &attr_mem), &declaration);
+        if (!declaration) {
+            // let's be curious and look deeper in the tree,
+            // function are not necessarily at the first level, but
+            // might be nested inside a namespace, structure etc.
+            if (find_fundie_by_pc(&die, pc))
+                return true;
+        }
+    } while (dwarf_siblingof(&die, &die) == 0);
+    return false;
+}
+
+Dwarf_Die *find_die(Dwfl_Module *mod, Dwarf_Addr addr, Dwarf_Addr *bias)
+{
+    auto die = dwfl_module_addrdie(mod, addr, bias);
+    if (die)
+        return die;
+
+    while ((die = dwfl_module_nextcu(mod, die, bias))) {
+        if (find_fundie_by_pc(die, addr - *bias))
+            return die;
+    }
+
+    return nullptr;
+}
+
 int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
                                  bool *isInterworking)
 {
@@ -585,12 +656,6 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
     if (mod) {
         // For addrinfo we need the raw pointer into symtab, so we need to adjust ourselves.
         symname = dwfl_module_addrinfo(mod, addressLocation.address, &off, &sym, 0, 0, 0);
-        Dwfl_Line *srcLine = dwfl_module_getsrc(mod, addressLocation.address);
-        if (srcLine) {
-            const QByteArray file = dwfl_lineinfo(srcLine, NULL, &addressLocation.line,
-                                                 &addressLocation.column, NULL, NULL);
-            addressLocation.file = m_unwind->resolveString(file);
-        }
 
         if (off == addressLocation.address) {// no symbol found
             functionLocation.address = elfStart; // use the start of the elf as "function"
@@ -598,7 +663,23 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
         } else {
             Dwarf_Addr bias = 0;
             functionLocation.address -= off; // in case we don't find anything better
-            Dwarf_Die *die = dwfl_module_addrdie(mod, addressLocation.address, &bias);
+            Dwarf_Die *die = find_die(mod, addressLocation.address, &bias);
+
+            if (die) {
+                auto srcloc = dwarf_getsrc_die(die, addressLocation.address - bias);
+                if (srcloc) {
+                    const char* srcfile = dwarf_linesrc(srcloc, nullptr, nullptr);
+                    int line, column;
+                    dwarf_lineno(srcloc, &line);
+                    dwarf_linecol(srcloc, &column);
+                    if (srcfile) {
+                        const QByteArray file = srcfile;
+                        addressLocation.file = m_unwind->resolveString(file);
+                        addressLocation.line = line;
+                        addressLocation.column = column;
+                    }
+                }
+            }
 
             Dwarf_Die *scopes = NULL;
             int nscopes = dwarf_getscopes(die, addressLocation.address - bias, &scopes);

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -693,7 +693,6 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
 
         if (off == addressLocation.address) {// no symbol found
             symname = fakeSymbolFromSection(mod, addressLocation.address);
-            functionLocation.address = elfStart; // use the start of the elf as "function"
             addressLocation.parentLocationId = m_unwind->resolveLocation(functionLocation);
         } else {
             Dwarf_Addr bias = 0;

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -464,7 +464,7 @@ void PerfSymbolTable::parseDwarf(Dwarf_Die *cudie, Dwarf_Addr bias, qint32 binar
 
 static void reportError(const PerfElfMap::ElfInfo& info, const char *message)
 {
-    qWarning() << "failed to report" << info.localFile.absoluteFilePath() << "for"
+    qWarning() << "failed to report" << info << "for"
                << hex << info.addr << dec << ":" << message;
 }
 

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -624,6 +624,40 @@ Dwarf_Die *find_die(Dwfl_Module *mod, Dwarf_Addr addr, Dwarf_Addr *bias)
     return nullptr;
 }
 
+static QByteArray fakeSymbolFromSection(Dwfl_Module *mod, Dwarf_Addr addr)
+{
+    Dwarf_Addr bias = 0;
+    auto elf = dwfl_module_getelf(mod, &bias);
+    const auto moduleAddr = addr - bias;
+    auto section = dwfl_module_address_section(mod, &addr, &bias);
+    if (!elf || !section)
+        return {};
+
+    size_t textSectionIndex = 0;
+    if (elf_getshdrstrndx(elf, &textSectionIndex) != 0)
+        return {};
+
+    size_t offset = 0;
+    if (auto shdr = elf64_getshdr(section)) {
+        offset = shdr->sh_name;
+    } else if (auto shdr = elf32_getshdr(section)) {
+        offset = shdr->sh_name;
+    }
+
+    auto str = elf_strptr(elf, textSectionIndex, offset);
+    if (!str || str == QLatin1String(".text"))
+        return {};
+
+    // mark .plt entries etc. by section name, see also:
+    // http://www.mail-archive.com/elfutils-devel@sourceware.org/msg00019.html
+    QByteArray sym = str;
+    sym.prepend('<');
+    sym.append('+');
+    sym.append(QByteArray::number(quint64(moduleAddr), 16));
+    sym.append('>');
+    return sym;
+}
+
 int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
                                  bool *isInterworking)
 {
@@ -658,6 +692,7 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
         symname = dwfl_module_addrinfo(mod, addressLocation.address, &off, &sym, 0, 0, 0);
 
         if (off == addressLocation.address) {// no symbol found
+            symname = fakeSymbolFromSection(mod, addressLocation.address);
             functionLocation.address = elfStart; // use the start of the elf as "function"
             addressLocation.parentLocationId = m_unwind->resolveLocation(functionLocation);
         } else {

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -117,13 +117,7 @@ static bool accessDsoMem(Dwfl *dwfl, const PerfUnwind::UnwindInfo *ui, Dwarf_Add
                          Dwarf_Word *result, uint wordWidth)
 {
     // TODO: Take the pgoff into account? Or does elf_getdata do that already?
-    Dwfl_Module *mod = dwfl ? dwfl_addrmodule(dwfl, addr) : nullptr;
-
-    if (!mod) {
-        mod = ui->unwind->reportElf(addr, ui->sample->pid());
-        if (!mod)
-            return false;
-    }
+    auto mod = ui->unwind->symbolTable(ui->sample->pid())->module(addr);
 
     Dwarf_Addr bias;
     Elf_Scn *section = dwfl_module_address_section(mod, &addr, &bias);
@@ -496,6 +490,27 @@ Dwfl_Module *PerfSymbolTable::reportElf(const PerfElfMap::ElfInfo& info)
     return ret;
 }
 
+Dwfl_Module *PerfSymbolTable::module(quint64 addr)
+{
+    if (!m_dwfl)
+        return nullptr;
+
+    Dwfl_Module *mod = dwfl_addrmodule(m_dwfl, addr);
+    const auto &elf = findElf(addr);
+
+    if (mod) {
+        // If dwfl has a module and it's not the same as what we want, report the module
+        // we want. Many modules overlap ld.so, so if we've reported even one sample from
+        // ld.so we would otherwise be blocked from reporting anything that overlaps it.
+        Dwarf_Addr mod_start = 0;
+        dwfl_module_info(mod, nullptr, &mod_start, nullptr, nullptr, nullptr, nullptr,
+                         nullptr);
+        if (elf.addr == mod_start)
+            return mod;
+    }
+    return reportElf(elf);
+}
+
 int PerfSymbolTable::findDebugInfo(Dwfl_Module *module, const char *moduleName, Dwarf_Addr base,
                                    const char *file, const char *debugLink,
                                    GElf_Word crc, char **debugInfoFilename)
@@ -547,30 +562,16 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
         return it->locationId;
     }
 
-    Dwfl_Module *mod = m_dwfl ? dwfl_addrmodule(m_dwfl, ip) : 0;
     qint32 binaryId = -1;
-
     quint64 elfStart = 0;
 
     const auto& elf = findElf(ip);
     if (elf.isValid()) {
         binaryId = m_unwind->resolveString(elf.originalFileName);
         elfStart = elf.addr;
-        if (m_dwfl) {
-            if (mod) {
-                // If dwfl has a module and it's not the same as what we want, report the module
-                // we want. Many modules overlap ld.so, so if we've reported even one sample from
-                // ld.so we would otherwise be blocked from reporting anything that overlaps it.
-                Dwarf_Addr mod_start = 0;
-                dwfl_module_info(mod, nullptr, &mod_start, nullptr, nullptr, nullptr, nullptr,
-                                 nullptr);
-                if (elfStart != mod_start)
-                    mod = reportElf(elf);
-            } else {
-                mod = reportElf(elf);
-            }
-        }
     }
+
+    Dwfl_Module *mod = module(ip);
 
     PerfUnwind::Location addressLocation(
                 (m_unwind->architecture() != PerfRegisterInfo::ARCH_ARM || (ip & 1))

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -325,7 +325,7 @@ void PerfSymbolTable::registerElf(const PerfRecordMmap &mmap, const QByteArray &
     }
 
     bool cacheInvalid = m_elfs.registerElf(mmap.addr(), mmap.len(), mmap.pgoff(), fullPath,
-                                           fileName.toUtf8());
+                                           fileName.toUtf8(), mmap.filename());
 
     // There is no need to clear the symbol or location caches in PerfUnwind. Some locations become
     // stale this way, but we still need to keep their IDs, as the receiver might still use them for
@@ -506,7 +506,17 @@ int PerfSymbolTable::findDebugInfo(Dwfl_Module *module, const char *moduleName, 
 
     // fall-back, mostly for situations where we loaded a file via it's build-id.
     // search all known paths for the debug link in that case
-    const auto debugLinkFile = findFile(debugLink, QFile(debugLink).fileName());
+    const auto debugLinkString = QFile(debugLink).fileName();
+    auto debugLinkFile = findFile(debugLink, debugLinkString);
+    if (!debugLinkFile.isFile()) {
+        // fall-back to original file path with debug link file name
+        const auto &elf = m_elfs.findElf(base);
+        const auto &dir = QFileInfo(m_unwind->systemRoot() + QString::fromUtf8(elf.originalPath)).absoluteDir();
+        debugLinkFile.setFile(dir, debugLinkString);
+        if (!debugLinkFile.isFile()) // try again in .debug folder
+            debugLinkFile.setFile(dir, QLatin1String(".debug") + QDir::separator() + debugLinkString);
+    }
+
     if (!debugLinkFile.isFile())
         return ret;
 

--- a/app/perfsymboltable.h
+++ b/app/perfsymboltable.h
@@ -60,6 +60,8 @@ public:
     // Report an mmap to dwfl and parse it for symbols and inlines, or simply return it if dwfl has
     // it already
     Dwfl_Module *reportElf(const PerfElfMap::ElfInfo& elf);
+    // Find the module for the given address and report it if needed
+    Dwfl_Module *module(quint64 addr);
     int findDebugInfo(Dwfl_Module *module, const char *moduleName, Dwarf_Addr base,
                       const char *file, const char *debugLink,
                       GElf_Word crc, char **debugInfoFilename);

--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -222,7 +222,8 @@ void PerfUnwind::sendAttributes(qint32 id, const PerfEventAttributes &attributes
     QByteArray buffer;
     QDataStream(&buffer, QIODevice::WriteOnly) << static_cast<quint8>(AttributesDefinition)
                                                << id << attributes.type()
-                                               << attributes.config() << attrNameId;
+                                               << attributes.config() << attrNameId
+                                               << attributes.usesFrequency() << attributes.frequenyOrPeriod();
     sendBuffer(buffer);
 }
 

--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -300,8 +300,10 @@ static int frameCallback(Dwfl_Frame *state, void *arg)
     Dwarf_Addr pc = 0;
     PerfUnwind::UnwindInfo *ui = static_cast<PerfUnwind::UnwindInfo *>(arg);
 
-    bool isactivation;
-    if (!dwfl_frame_pc(state, &pc, &isactivation)
+    // do not query for activation directly, as this could potentially advance
+    // the unwinder internally - we must first ensure the module for the pc
+    // is reported
+    if (!dwfl_frame_pc(state, &pc, NULL)
             || (ui->maxFrames != -1 && ui->frames.length() > ui->maxFrames)
             || pc == 0) {
         ui->firstGuessedFrame = ui->frames.length();
@@ -309,9 +311,17 @@ static int frameCallback(Dwfl_Frame *state, void *arg)
         return DWARF_CB_ABORT;
     }
 
+    auto* symbolTable = ui->unwind->symbolTable(ui->sample->pid());
+
+    // ensure the module is reported
+    if (!symbolTable->module(pc))
+        return DWARF_CB_ABORT;
+
+    // now we can query for the activation flag
+    bool isactivation = false;
+    dwfl_frame_pc(state, &pc, &isactivation);
     Dwarf_Addr pc_adjusted = pc - (isactivation ? 0 : 1);
 
-    auto* symbolTable = ui->unwind->symbolTable(ui->sample->pid());
     // isKernel = false as unwinding generally only works on user code
     bool isInterworking = false;
     const auto frame = symbolTable->lookupFrame(pc_adjusted, false, &isInterworking);

--- a/app/perfunwind.h
+++ b/app/perfunwind.h
@@ -101,7 +101,8 @@ public:
 
     PerfUnwind(QIODevice *output, const QString &systemRoot, const QString &debugInfo,
                const QString &extraLibs, const QString &appPath,
-               const QString &kallsymsPath, bool printStats, uint maxEventBufferSize,
+               const QString &kallsymsPath, bool ignoreKallsymsBuildId,
+               bool printStats, uint maxEventBufferSize,
                int maxFrames);
     ~PerfUnwind();
 
@@ -194,6 +195,7 @@ private:
 
     // Path to kallsyms path
     QString m_kallsymsPath;
+    bool m_ignoreKallsymsBuildId;
 
     QList<PerfRecordSample> m_sampleBuffer;
     QList<PerfRecordMmap> m_mmapBuffer;

--- a/app/perfunwind.h
+++ b/app/perfunwind.h
@@ -140,7 +140,7 @@ public:
     bool hasSymbol(int locationId) const;
     void resolveSymbol(int locationId, const Symbol &symbol);
 
-    PerfKallsymEntry findKallsymEntry(quint64 address) const;
+    PerfKallsymEntry findKallsymEntry(quint64 address);
 
     enum ErrorCode {
         TimeOrderViolation = 1,
@@ -191,6 +191,9 @@ private:
 
     // Path to debug information, e.g. ~/.debug and /usr/local/debug
     QString m_debugPath;
+
+    // Path to kallsyms path
+    QString m_kallsymsPath;
 
     QList<PerfRecordSample> m_sampleBuffer;
     QList<PerfRecordMmap> m_mmapBuffer;

--- a/tests/auto/elfmap/tst_elfmap.cpp
+++ b/tests/auto/elfmap/tst_elfmap.cpp
@@ -27,8 +27,8 @@
 namespace {
 bool registerElf(PerfElfMap *map, const PerfElfMap::ElfInfo &info)
 {
-    return map->registerElf(info.addr, info.length, info.pgoff,
-                            info.localFile, info.originalFileName);
+    return map->registerElf(info.addr, info.length, info.pgoff, info.localFile,
+                            info.originalFileName, info.originalPath);
 }
 }
 


### PR DESCRIPTION
The perf version that I'm using on my AMD Geode "embedded" system
(perf 4.9.23, built via a random version of Buildroot) apparently
produces traces which require this change to treat "i586" as the "x86"
architecture.