### PR TITLE
Check for 0 sized section header plt in fakeSymbolFromSection to prevent div by 0

### DIFF
--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -940,7 +940,7 @@ static QByteArray fakeSymbolFromSection(Dwfl_Module *mod, Dwarf_Addr addr)
     if (!str || str == QLatin1String(".text"))
         return {};
 
-    if (str == QLatin1String(".plt")) {
+    if (str == QLatin1String(".plt") && entsize > 0) {
         const auto *pltSymbol = findPltSymbol(elf, addr / entsize);
         if (pltSymbol)
             return demangle(pltSymbol) + "@plt";


### PR DESCRIPTION
This checks for div by 0 in only fakeSymbolFromSection. There are a few other places where we divide by entsize, but I didn't try to fix those since I don't understand the situation well enough yet.

This resolve the problem seen in KDAB/hotspot/issues/163.

