### PR TITLE
Revert to logic before a74ed5e305e0525b851a85736eaaca46c3b726e9 

### DIFF
--- a/app/perfelfmap.cpp
+++ b/app/perfelfmap.cpp
@@ -76,27 +76,8 @@ void PerfElfMap::registerElf(quint64 addr, quint64 len, quint64 pgoff,
     QVarLengthArray<int, 8> removedElfs;
     for (auto i = m_elfs.begin(), end = m_elfs.end(); i != end && i->addr < addrEnd; ++i) {
         const quint64 iEnd = i->addr + i->length;
-        if (iEnd < addr)
+        if (iEnd <= addr)
             continue;
-
-        if (addr - pgoff == i->addr - i->pgoff && originalPath == i->originalPath) {
-            // Remapping parts of the same file in the same place: Extend to maximum continuous	71
-            // address range and check if we already have that.
-            addr = qMin(addr, i->addr);
-            pgoff = qMin(pgoff, i->pgoff);
-            addrEnd = qMax(addrEnd, iEnd);
-            len = addrEnd - addr;
-            if (addr == i->addr && len == i->length) {
-                // New mapping is fully contained in old one: Nothing to do.
-                Q_ASSERT(newElfs.isEmpty());
-                Q_ASSERT(removedElfs.isEmpty());
-                return;
-            }
-        } else if (iEnd == addr) {
-            // Directly adjacent sections of the same file can be merged. Ones of different files
-            // don't bother each other.
-            continue;
-        }
 
         // Newly added elf overwrites existing one. Mark the existing one as overwritten and
         // reinsert any fragments of it that remain.


### PR DESCRIPTION
to avoid bug/edge case seen in KDAB/hotspot/issues/164 where `findElf`/`PerfSymbolTable::module` gets stuck in a loop looking for `baseAddr`.

There might be a narrower fix, but I don't understand the problem yet well enough to make that fix.