### PR TITLE
Add initial MIPS support

### DIFF
--- a/app/perfregisterinfo.cpp
+++ b/app/perfregisterinfo.cpp
@@ -51,6 +51,9 @@ static int aarch64[] = { 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 
 static int x86[] = {0, 2, 3, 1, 7, 6, 4, 5, 8};
 static int x86_64[] = {0, 3, 2, 1, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23, 8};
 
+static int mips[] = { 32,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17,
+                        18, 19, 20, 21, 22, 23, 24, 25, 28, 29, 30, 31};
+
 static int none[] = {0};
 
 const int *PerfRegisterInfo::s_perfToDwarf[PerfRegisterInfo::ARCH_INVALID][PerfRegisterInfo::s_numAbis] = {
@@ -60,7 +63,8 @@ const int *PerfRegisterInfo::s_perfToDwarf[PerfRegisterInfo::ARCH_INVALID][PerfR
     {none,    none   },
     {none,    none   },
     {none,    none   },
-    {x86,     x86_64 }
+    {x86,     x86_64 },
+    {mips,    mips   },
 };
 
 const int PerfRegisterInfo::s_perfIp[ARCH_INVALID] = {
@@ -146,6 +150,9 @@ PerfRegisterInfo::Architecture PerfRegisterInfo::archByName(const QByteArray &na
             || QRegularExpression("^i[3-7]86$").match(name).hasMatch()
             || name == "amd64")
         return ARCH_X86;
+
+    if (name.startsWith("mips"))
+        return ARCH_MIPS;
 
     return ARCH_INVALID;
 }

--- a/app/perfregisterinfo.h
+++ b/app/perfregisterinfo.h
@@ -34,6 +34,7 @@ public:
         ARCH_SH,
         ARCH_SPARC,
         ARCH_X86,
+        ARCH_MIPS,
         ARCH_INVALID
     };
 


### PR DESCRIPTION
Supports perf reports from MIPS targets.

MIPS/perf isn't really supported on the mainstream Linux kernel, but
there are a number of patches around which can be used to build
working perf support:

https://lkml.org/lkml/2016/4/1/162

This change just adds the definitions required by hotspot to
support this.