### PR TITLE
fix: match types exactly to resolve qcompare link error

### DIFF
--- a/tests/auto/addresscache/tst_addresscache.cpp
+++ b/tests/auto/addresscache/tst_addresscache.cpp
@@ -80,9 +80,9 @@ private slots:
         for (auto addr : {0x100, 0x100 + 9}) {
             const auto cached = cache.findSymbol(info_a, addr);
             QVERIFY(cached.isValid());
-            QCOMPARE(cached.offset, 0);
-            QCOMPARE(cached.size, 10);
-            QCOMPARE(cached.symname, "Foo");
+            QCOMPARE(cached.offset, 0ull);
+            QCOMPARE(cached.size, 10ull);
+            QCOMPARE(cached.symname, QByteArrayLiteral("Foo"));
         }
         QVERIFY(!cache.findSymbol(info_a, 0x100 + 10).isValid());
         QVERIFY(!cache.findSymbol(info_b, 0x100).isValid());


### PR DESCRIPTION
Resolve link error:

```[ 21%] Linking CXX executable tst_addresscache
CMakeFiles/tst_addresscache.dir/perfparser/tests/auto/addresscache/tst_addresscache.cpp.o: In function `TestAddressCache::testSymbolCache()':
tst_addresscache.cpp:(.text._ZN16TestAddressCache15testSymbolCacheEv[_ZN16TestAddressCache15testSymbolCacheEv]+0x84e): undefined reference to `bool QTest::qCompare<unsigned long long, int>(unsigned long long const&, int const&, char const*, char const*, char const*, int)'
tst_addresscache.cpp:(.text._ZN16TestAddressCache15testSymbolCacheEv[_ZN16TestAddressCache15testSymbolCacheEv]+0x885): undefined reference to `bool QTest::qCompare<unsigned long long, int>(unsigned long long const&, int const&, char const*, char const*, char const*, int)'
tst_addresscache.cpp:(.text._ZN16TestAddressCache15testSymbolCacheEv[_ZN16TestAddressCache15testSymbolCacheEv]+0x8b8): undefined reference to `bool QTest::qCompare<QByteArray, char [4]>(QByteArray const&, char const (&) [4], char const*, char const*, char const*, int)'
collect2: error: ld returned 1 exit status
3rdparty/CMakeFiles/tst_addresscache.dir/build.make:174: recipe for target '3rdparty/tst_addresscache' failed
make[2]: *** [3rdparty/tst_addresscache] Error 1
CMakeFiles/Makefile2:235: recipe for target '3rdparty/CMakeFiles/tst_addresscache.dir/all' failed
make[1]: *** [3rdparty/CMakeFiles/tst_addresscache.dir/all] Error 2
Makefile:140: recipe for target 'all' faile```