### PR TITLE
feat: sync PerfEventType with linux 5.6 perf_user_event_type and perf_event_type

### DIFF
--- a/app/perfdata.cpp
+++ b/app/perfdata.cpp
@@ -38,6 +38,47 @@ void PerfData::setSource(QIODevice *source)
     m_source = source;
 }
 
+const char * perfEventToString(qint32 type)
+{
+    switch(type)
+    {
+    case PERF_RECORD_MMAP:                return "PERF_RECORD_MMAP";
+    case PERF_RECORD_LOST:                return "PERF_RECORD_LOST";
+    case PERF_RECORD_COMM:                return "PERF_RECORD_COMM";
+    case PERF_RECORD_EXIT:                return "PERF_RECORD_EXIT";
+    case PERF_RECORD_THROTTLE:            return "PERF_RECORD_THROTTLE";
+    case PERF_RECORD_UNTHROTTLE:          return "PERF_RECORD_UNTHROTTLE";
+    case PERF_RECORD_FORK:                return "PERF_RECORD_FORK";
+    case PERF_RECORD_READ:                return "PERF_RECORD_READ";
+    case PERF_RECORD_SAMPLE:              return "PERF_RECORD_SAMPLE";
+    case PERF_RECORD_MMAP2:               return "PERF_RECORD_MMAP2";
+    case PERF_RECORD_SWITCH:              return "PERF_RECORD_SWITCH";
+    case PERF_RECORD_SWITCH_CPU_WIDE:     return "PERF_RECORD_SWITCH_CPU_WIDE";
+    case PERF_RECORD_NAMESPACES:          return "PERF_RECORD_NAMESPACES";
+    case PERF_RECORD_KSYMBOL:             return "PERF_RECORD_KSYMBOL";
+    case PERF_RECORD_BPF_EVENT:           return "PERF_RECORD_BPF_EVENT";
+    case PERF_RECORD_HEADER_ATTR:         return "PERF_RECORD_HEADER_ATTR";
+    case PERF_RECORD_HEADER_EVENT_TYPE:   return "PERF_RECORD_HEADER_EVENT_TYPE";
+    case PERF_RECORD_HEADER_TRACING_DATA: return "PERF_RECORD_HEADER_TRACING_DATA";
+    case PERF_RECORD_HEADER_BUILD_ID:     return "PERF_RECORD_HEADER_BUILD_ID";
+    case PERF_RECORD_FINISHED_ROUND:      return "PERF_RECORD_FINISHED_ROUND";
+    case PERF_RECORD_ID_INDEX:            return "PERF_RECORD_ID_INDEX";
+    case PERF_RECORD_AUXTRACE_INFO:       return "PERF_RECORD_AUXTRACE_INFO";
+    case PERF_RECORD_AUXTRACE:            return "PERF_RECORD_AUXTRACE";
+    case PERF_RECORD_AUXTRACE_ERROR:      return "PERF_RECORD_AUXTRACE_ERROR";
+    case PERF_RECORD_THREAD_MAP:          return "PERF_RECORD_THREAD_MAP";
+    case PERF_RECORD_CPU_MAP:             return "PERF_RECORD_CPU_MAP";
+    case PERF_RECORD_STAT_CONFIG:         return "PERF_RECORD_STAT_CONFIG";
+    case PERF_RECORD_STAT:                return "PERF_RECORD_STAT";
+    case PERF_RECORD_STAT_ROUND:          return "PERF_RECORD_STAT_ROUND";
+    case PERF_RECORD_EVENT_UPDATE:        return "PERF_RECORD_EVENT_UPDATE";
+    case PERF_RECORD_TIME_CONV:           return "PERF_RECORD_TIME_CONV";
+    case PERF_RECORD_HEADER_FEATURE:      return "PERF_RECORD_HEADER_FEATURE";
+    case PERF_RECORD_COMPRESSED:          return "PERF_RECORD_COMPRESSED";
+    }
+    return "uknown type";
+}
+
 PerfData::ReadStatus PerfData::processEvents(QDataStream &stream)
 {
     const quint16 headerSize = PerfEventHeader::fixedLength();
@@ -187,7 +228,7 @@ PerfData::ReadStatus PerfData::processEvents(QDataStream &stream)
     }
 
     default:
-        qWarning() << "unhandled event type" << m_eventHeader.type;
+        qWarning() << "unhandled event type" << m_eventHeader.type << " " << perfEventToString(m_eventHeader.type);
         stream.skipRawData(contentSize);
         break;
     }

--- a/app/perfdata.h
+++ b/app/perfdata.h
@@ -225,7 +225,67 @@ enum PerfEventType {
      */
     PERF_RECORD_SWITCH            = 14,
 
-    PERF_RECORD_MAX,              /* non-ABI */
+    /*
+     * CPU-wide version of PERF_RECORD_SWITCH with next_prev_pid and
+     * next_prev_tid that are the next (switching out) or previous
+     * (switching in) pid/tid.
+     *
+     * struct {
+     *    struct perf_event_header    header;
+     *    u32                next_prev_pid;
+     *    u32                next_prev_tid;
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_SWITCH_CPU_WIDE        = 15,
+
+    /*
+     * struct {
+     *    struct perf_event_header    header;
+     *    u32                pid;
+     *    u32                tid;
+     *    u64                nr_namespaces;
+     *    { u64                dev, inode; } [nr_namespaces];
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_NAMESPACES            = 16,
+
+    /*
+     * Record ksymbol register/unregister events:
+     *
+     * struct {
+     *    struct perf_event_header    header;
+     *    u64                addr;
+     *    u32                len;
+     *    u16                ksym_type;
+     *    u16                flags;
+     *    char                name[];
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_KSYMBOL            = 17,
+
+    /*
+     * Record bpf events:
+     *  enum perf_bpf_event_type {
+     *    PERF_BPF_EVENT_UNKNOWN        = 0,
+     *    PERF_BPF_EVENT_PROG_LOAD    = 1,
+     *    PERF_BPF_EVENT_PROG_UNLOAD    = 2,
+     *  };
+     *
+     * struct {
+     *    struct perf_event_header    header;
+     *    u16                type;
+     *    u16                flags;
+     *    u32                id;
+     *    u8                tag[BPF_TAG_SIZE];
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_BPF_EVENT            = 18,
+
+    PERF_RECORD_MAX,            /* non-ABI */
 
     PERF_RECORD_USER_TYPE_START     = 64,
     PERF_RECORD_HEADER_ATTR         = 64,
@@ -233,6 +293,19 @@ enum PerfEventType {
     PERF_RECORD_HEADER_TRACING_DATA = 66,
     PERF_RECORD_HEADER_BUILD_ID     = 67,
     PERF_RECORD_FINISHED_ROUND      = 68,
+    PERF_RECORD_ID_INDEX            = 69,
+    PERF_RECORD_AUXTRACE_INFO       = 70,
+    PERF_RECORD_AUXTRACE            = 71,
+    PERF_RECORD_AUXTRACE_ERROR      = 72,
+    PERF_RECORD_THREAD_MAP          = 73,
+    PERF_RECORD_CPU_MAP             = 74,
+    PERF_RECORD_STAT_CONFIG         = 75,
+    PERF_RECORD_STAT                = 76,
+    PERF_RECORD_STAT_ROUND          = 77,
+    PERF_RECORD_EVENT_UPDATE        = 78,
+    PERF_RECORD_TIME_CONV           = 79,
+    PERF_RECORD_HEADER_FEATURE      = 80,
+    PERF_RECORD_COMPRESSED          = 81,
     PERF_RECORD_HEADER_MAX
 };
 


### PR DESCRIPTION
There are new event types, add them to our PerfEventType and also add a function to convert them to strings for log messages

Turns warning messages like:
```
unhandled event type 79
unhandled event type 73
unhandled event type 74
unhandled event type 17
unhandled event type 18
unhandled event type 17
unhandled event type 18
unhandled event type 17
unhandled event type 18
unhandled event type 17
unhandled event type 18
unhandled event type 17
unhandled event type 18
unhandled event type 17
unhandled event type 18
```
into warning messages like:
```
unhandled event type 79   PERF_RECORD_TIME_CONV
unhandled event type 73   PERF_RECORD_THREAD_MAP
unhandled event type 74   PERF_RECORD_CPU_MAP
unhandled event type 17   PERF_RECORD_KSYMBOL
unhandled event type 18   PERF_RECORD_BPF_EVENT
unhandled event type 17   PERF_RECORD_KSYMBOL
unhandled event type 18   PERF_RECORD_BPF_EVENT
unhandled event type 17   PERF_RECORD_KSYMBOL
unhandled event type 18   PERF_RECORD_BPF_EVENT
unhandled event type 17   PERF_RECORD_KSYMBOL
unhandled event type 18   PERF_RECORD_BPF_EVENT
unhandled event type 17   PERF_RECORD_KSYMBOL
unhandled event type 18   PERF_RECORD_BPF_EVENT
unhandled event type 17   PERF_RECORD_KSYMBOL
unhandled event type 18   PERF_RECORD_BPF_EVENT
```