### PR TITLE
Fix for bug #241 Perfparser/Hotspot cannot unwind the stack for fork(…

### DIFF
--- a/app/perfattributes.cpp
+++ b/app/perfattributes.cpp
@@ -25,7 +25,7 @@
 
 PerfEventAttributes::PerfEventAttributes()
 {
-    *this = PerfEventAttributes{};
+    memset(this, 0, sizeof(PerfEventAttributes));
 }
 
 QDataStream &operator>>(QDataStream &stream, PerfEventAttributes &attrs)

--- a/app/perfdata.cpp
+++ b/app/perfdata.cpp
@@ -38,6 +38,47 @@ void PerfData::setSource(QIODevice *source)
     m_source = source;
 }
 
+const char * perfEventToString(qint32 type)
+{
+    switch(type)
+    {
+    case PERF_RECORD_MMAP:                return "PERF_RECORD_MMAP";
+    case PERF_RECORD_LOST:                return "PERF_RECORD_LOST";
+    case PERF_RECORD_COMM:                return "PERF_RECORD_COMM";
+    case PERF_RECORD_EXIT:                return "PERF_RECORD_EXIT";
+    case PERF_RECORD_THROTTLE:            return "PERF_RECORD_THROTTLE";
+    case PERF_RECORD_UNTHROTTLE:          return "PERF_RECORD_UNTHROTTLE";
+    case PERF_RECORD_FORK:                return "PERF_RECORD_FORK";
+    case PERF_RECORD_READ:                return "PERF_RECORD_READ";
+    case PERF_RECORD_SAMPLE:              return "PERF_RECORD_SAMPLE";
+    case PERF_RECORD_MMAP2:               return "PERF_RECORD_MMAP2";
+    case PERF_RECORD_SWITCH:              return "PERF_RECORD_SWITCH";
+    case PERF_RECORD_SWITCH_CPU_WIDE:     return "PERF_RECORD_SWITCH_CPU_WIDE";
+    case PERF_RECORD_NAMESPACES:          return "PERF_RECORD_NAMESPACES";
+    case PERF_RECORD_KSYMBOL:             return "PERF_RECORD_KSYMBOL";
+    case PERF_RECORD_BPF_EVENT:           return "PERF_RECORD_BPF_EVENT";
+    case PERF_RECORD_HEADER_ATTR:         return "PERF_RECORD_HEADER_ATTR";
+    case PERF_RECORD_HEADER_EVENT_TYPE:   return "PERF_RECORD_HEADER_EVENT_TYPE";
+    case PERF_RECORD_HEADER_TRACING_DATA: return "PERF_RECORD_HEADER_TRACING_DATA";
+    case PERF_RECORD_HEADER_BUILD_ID:     return "PERF_RECORD_HEADER_BUILD_ID";
+    case PERF_RECORD_FINISHED_ROUND:      return "PERF_RECORD_FINISHED_ROUND";
+    case PERF_RECORD_ID_INDEX:            return "PERF_RECORD_ID_INDEX";
+    case PERF_RECORD_AUXTRACE_INFO:       return "PERF_RECORD_AUXTRACE_INFO";
+    case PERF_RECORD_AUXTRACE:            return "PERF_RECORD_AUXTRACE";
+    case PERF_RECORD_AUXTRACE_ERROR:      return "PERF_RECORD_AUXTRACE_ERROR";
+    case PERF_RECORD_THREAD_MAP:          return "PERF_RECORD_THREAD_MAP";
+    case PERF_RECORD_CPU_MAP:             return "PERF_RECORD_CPU_MAP";
+    case PERF_RECORD_STAT_CONFIG:         return "PERF_RECORD_STAT_CONFIG";
+    case PERF_RECORD_STAT:                return "PERF_RECORD_STAT";
+    case PERF_RECORD_STAT_ROUND:          return "PERF_RECORD_STAT_ROUND";
+    case PERF_RECORD_EVENT_UPDATE:        return "PERF_RECORD_EVENT_UPDATE";
+    case PERF_RECORD_TIME_CONV:           return "PERF_RECORD_TIME_CONV";
+    case PERF_RECORD_HEADER_FEATURE:      return "PERF_RECORD_HEADER_FEATURE";
+    case PERF_RECORD_COMPRESSED:          return "PERF_RECORD_COMPRESSED";
+    }
+    return "uknown type";
+}
+
 PerfData::ReadStatus PerfData::processEvents(QDataStream &stream)
 {
     const quint16 headerSize = PerfEventHeader::fixedLength();
@@ -187,7 +228,7 @@ PerfData::ReadStatus PerfData::processEvents(QDataStream &stream)
     }
 
     default:
-        qWarning() << "unhandled event type" << m_eventHeader.type;
+        qWarning() << "unhandled event type" << m_eventHeader.type << " " << perfEventToString(m_eventHeader.type);
         stream.skipRawData(contentSize);
         break;
     }

--- a/app/perfdata.h
+++ b/app/perfdata.h
@@ -225,7 +225,67 @@ enum PerfEventType {
      */
     PERF_RECORD_SWITCH            = 14,
 
-    PERF_RECORD_MAX,              /* non-ABI */
+    /*
+     * CPU-wide version of PERF_RECORD_SWITCH with next_prev_pid and
+     * next_prev_tid that are the next (switching out) or previous
+     * (switching in) pid/tid.
+     *
+     * struct {
+     *    struct perf_event_header    header;
+     *    u32                next_prev_pid;
+     *    u32                next_prev_tid;
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_SWITCH_CPU_WIDE        = 15,
+
+    /*
+     * struct {
+     *    struct perf_event_header    header;
+     *    u32                pid;
+     *    u32                tid;
+     *    u64                nr_namespaces;
+     *    { u64                dev, inode; } [nr_namespaces];
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_NAMESPACES            = 16,
+
+    /*
+     * Record ksymbol register/unregister events:
+     *
+     * struct {
+     *    struct perf_event_header    header;
+     *    u64                addr;
+     *    u32                len;
+     *    u16                ksym_type;
+     *    u16                flags;
+     *    char                name[];
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_KSYMBOL            = 17,
+
+    /*
+     * Record bpf events:
+     *  enum perf_bpf_event_type {
+     *    PERF_BPF_EVENT_UNKNOWN        = 0,
+     *    PERF_BPF_EVENT_PROG_LOAD    = 1,
+     *    PERF_BPF_EVENT_PROG_UNLOAD    = 2,
+     *  };
+     *
+     * struct {
+     *    struct perf_event_header    header;
+     *    u16                type;
+     *    u16                flags;
+     *    u32                id;
+     *    u8                tag[BPF_TAG_SIZE];
+     *    struct sample_id        sample_id;
+     * };
+     */
+    PERF_RECORD_BPF_EVENT            = 18,
+
+    PERF_RECORD_MAX,            /* non-ABI */
 
     PERF_RECORD_USER_TYPE_START     = 64,
     PERF_RECORD_HEADER_ATTR         = 64,
@@ -233,6 +293,19 @@ enum PerfEventType {
     PERF_RECORD_HEADER_TRACING_DATA = 66,
     PERF_RECORD_HEADER_BUILD_ID     = 67,
     PERF_RECORD_FINISHED_ROUND      = 68,
+    PERF_RECORD_ID_INDEX            = 69,
+    PERF_RECORD_AUXTRACE_INFO       = 70,
+    PERF_RECORD_AUXTRACE            = 71,
+    PERF_RECORD_AUXTRACE_ERROR      = 72,
+    PERF_RECORD_THREAD_MAP          = 73,
+    PERF_RECORD_CPU_MAP             = 74,
+    PERF_RECORD_STAT_CONFIG         = 75,
+    PERF_RECORD_STAT                = 76,
+    PERF_RECORD_STAT_ROUND          = 77,
+    PERF_RECORD_EVENT_UPDATE        = 78,
+    PERF_RECORD_TIME_CONV           = 79,
+    PERF_RECORD_HEADER_FEATURE      = 80,
+    PERF_RECORD_COMPRESSED          = 81,
     PERF_RECORD_HEADER_MAX
 };
 

--- a/app/perfdata.h
+++ b/app/perfdata.h
@@ -558,6 +558,7 @@ public:
                    bool sampleIdAll = false);
     qint32 childTid() const { return m_tid; }
     qint32 childPid() const { return m_pid; }
+    qint32 parentPid() const { return m_ppid; }
 private:
     qint32 m_pid, m_ppid;
     qint32 m_tid, m_ptid;

--- a/app/perfheader.cpp
+++ b/app/perfheader.cpp
@@ -81,13 +81,13 @@ void PerfHeader::read()
         for (uint i = 0; i < featureParts; ++i)
             stream >> m_features[i];
 
-        if (m_magic == s_magicSwitched && !hasFeature(HOSTNAME)) {
+        if (m_magic == s_magicSwitched && !hasFeature(HOSTNAME) && !hasFeature(CMDLINE)) {
 
             quint32 *features32 = reinterpret_cast<quint32 *>(&m_features[0]);
             for (uint i = 0; i < featureParts; ++i)
                 qSwap(features32[i * 2], features32[i * 2 + 1]);
 
-            if (!hasFeature(HOSTNAME)) {
+            if (!hasFeature(HOSTNAME) && !hasFeature(CMDLINE)) {
                 // It borked: blank it all
                 qWarning() << "bad feature data:" << m_features;
                 for (uint i = 0; i < featureParts; ++i)

--- a/app/perfunwind.h
+++ b/app/perfunwind.h
@@ -334,6 +334,24 @@ private:
     void revertTargetEventBufferSize();
     bool hasTracePointAttributes() const;
 };
+// fork() creates a new process by duplicating the calling process.
+// Added new class to save reference to Symbol Table of parent process
+class PerfForkStart {
+public:
+    PerfForkStart(qint32 m_pid = 0, PerfSymbolTable *parentSym = nullptr) {
+        this->m_pid = m_pid;
+        this->parentSym = parentSym;
+    }
+
+    qint32 threadPid() const { return m_pid; }
+
+    PerfSymbolTable *symbol() const { return parentSym; }
+
+private:
+    qint32 m_pid;
+    PerfSymbolTable *parentSym;
+};
 
 uint qHash(const PerfUnwind::Location &location, uint seed = 0);
 bool operator==(const PerfUnwind::Location &a, const PerfUnwind::Location &b);
+bool findParentsSymTable(qint32 pid, PerfSymbolTable * * parent);

--- a/tests/auto/addresscache/tst_addresscache.cpp
+++ b/tests/auto/addresscache/tst_addresscache.cpp
@@ -80,9 +80,9 @@ private slots:
         for (auto addr : {0x100, 0x100 + 9}) {
             const auto cached = cache.findSymbol(info_a, addr);
             QVERIFY(cached.isValid());
-            QCOMPARE(int(cached.offset), 0);
-            QCOMPARE(int(cached.size), 10);
-            QCOMPARE(cached.symname, "Foo");
+            QCOMPARE(cached.offset, 0ull);
+            QCOMPARE(cached.size, 10ull);
+            QCOMPARE(cached.symname, QByteArrayLiteral("Foo"));
         }
         QVERIFY(!cache.findSymbol(info_a, 0x100 + 10).isValid());
         QVERIFY(!cache.findSymbol(info_b, 0x100).isValid());


### PR DESCRIPTION
…) of created processes
The fork() creates a new process by duplicating the calling process. The new process is referred to as the child process. The calling process is referred to as the parent process. Perf.data contains PERF_RECORD_MMAP2 events for the parent process, and therefore the Symbol Table of the parent process contains Elf information. For the child process, we do not have PERF_RECORD_MMAP2 events, and for this reason the Symbol Table for the child process does not contain any Elf information. And as a fact, we cannot unwind the stack for functions of child processes. Therefore, we should be able to use the Elf information of the parent process. To do this, write a link to the Symbol Table of the parent process in the std vector saveParentSymTable. We cannot copy Elf information from the Symbol table of the parent, as we will get an error on the destructor of the ElfAndFile class.