### PR TITLE
The Parent Pid (taskEvent.m_payload) for the ThreadStart

### DIFF
--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -1044,7 +1044,7 @@ void PerfUnwind::sendTaskEvent(const TaskEvent& taskEvent)
 
     if (taskEvent.m_type == ContextSwitchDefinition)
         stream << static_cast<bool>(taskEvent.m_payload);
-    else if (taskEvent.m_type == Command || taskEvent.m_type == ThreadStart)
+    else if (taskEvent.m_type == Command)
         stream << taskEvent.m_payload;
 
     sendBuffer(buffer);


### PR DESCRIPTION
event should not be reset to stream like it is for the Command event.
Parent Pid for ThreadStart event breaks stream structure