### PR TITLE
allow the user to use a custom perf map path

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -277,6 +277,14 @@ int main(int argc, char *argv[])
         QStringLiteral("max-frames"), QStringLiteral("64"));
     parser.addOption(maxFrames);
 
+    QCommandLineOption customPerfMapPath(
+        QStringLiteral("perf-map-path"),
+        QCoreApplication::translate("main",
+                                    "Specify a custom path where perfparser should look for a perf-$pid.map file"),
+        QStringLiteral("perf-map-path"));
+
+    parser.addOption(customPerfMapPath);
+
     parser.process(app);
 
     auto outfile = initOutfile(parser, output);
@@ -306,7 +314,9 @@ int main(int argc, char *argv[])
 
     PerfUnwind unwind(outfile.get(), parser.value(sysroot),
                       parser.isSet(debug) ? parser.value(debug) : parser.value(sysroot) + parser.value(debug),
-                      parser.value(extra), parser.value(appPath), parser.isSet(printStats));
+                      parser.value(extra), parser.value(appPath),
+                      parser.isSet(customPerfMapPath) ? parser.value(customPerfMapPath) : QString {},
+                      parser.isSet(printStats));
 
     unwind.setKallsymsPath(parser.isSet(kallsymsPath)
                            ? parser.value(kallsymsPath)

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -40,9 +40,21 @@
 #include <debuginfod.h>
 #endif
 
+namespace {
+QString perfMapFile(const QString& customPerfMapPath, int pid)
+{
+    if (!customPerfMapPath.isEmpty()) {
+        QString path = customPerfMapPath + QDir::separator() + QLatin1String("perf-%1.map").arg(QString::number(pid));
+        if (QFile::exists(path)) {
+            return path;
+        }
+    }
+    return QDir::tempPath() + QDir::separator() + QLatin1String("perf-%1.map").arg(QString::number(pid));
+}
+}
+
 PerfSymbolTable::PerfSymbolTable(qint32 pid, Dwfl_Callbacks *callbacks, PerfUnwind *parent) :
-    m_perfMapFile(QDir::tempPath() + QDir::separator()
-                  + QLatin1String("perf-%1.map").arg(QString::number(pid))),
+    m_perfMapFile(perfMapFile(parent->perfMapPath(), pid)),
     m_hasPerfMap(m_perfMapFile.exists()),
     m_cacheIsDirty(false),
     m_unwind(parent),

--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -240,13 +240,14 @@ QString PerfUnwind::defaultKallsymsPath()
     return QLatin1String("%1proc%1kallsyms").arg(QDir::separator());
 }
 
-PerfUnwind::PerfUnwind(QIODevice *output, const QString &systemRoot, const QString &debugPath,
-                       const QString &extraLibsPath, const QString &appPath, bool printStats) :
+PerfUnwind::PerfUnwind(QIODevice* output, const QString& systemRoot, const QString& debugPath,
+                       const QString& extraLibsPath, const QString& appPath, const QString& customPerfMapPath,
+                       bool printStats) :
     m_output(output), m_architecture(PerfRegisterInfo::ARCH_INVALID), m_systemRoot(systemRoot),
     m_extraLibsPath(extraLibsPath), m_appPath(appPath), m_debugPath(debugPath),
     m_kallsymsPath(QDir::rootPath() + defaultKallsymsPath()), m_ignoreKallsymsBuildId(false),
-    m_lastEventBufferSize(1 << 20), m_maxEventBufferSize(1 << 30), m_targetEventBufferSize(1 << 25),
-    m_eventBufferSize(0), m_timeOrderViolations(0), m_lastFlushMaxTime(0)
+    m_customPerfMapPath(customPerfMapPath), m_lastEventBufferSize(1 << 20), m_maxEventBufferSize(1 << 30),
+    m_targetEventBufferSize(1 << 25), m_eventBufferSize(0), m_timeOrderViolations(0), m_lastFlushMaxTime(0)
 {
     m_stats.enabled = printStats;
     m_currentUnwind.unwind = this;

--- a/app/perfunwind.h
+++ b/app/perfunwind.h
@@ -155,10 +155,9 @@ public:
     static QString defaultDebugInfoPath();
     static QString defaultKallsymsPath();
 
-    PerfUnwind(QIODevice *output, const QString &systemRoot = QDir::rootPath(),
-               const QString &debugPath = defaultDebugInfoPath(),
-               const QString &extraLibs = QString(), const QString &appPath = QString(),
-               bool printStats = false);
+    PerfUnwind(QIODevice* output, const QString& systemRoot = QDir::rootPath(),
+               const QString& debugPath = defaultDebugInfoPath(), const QString& extraLibs = QString(),
+               const QString& appPath = QString(), const QString& customPerfMapPath = {}, bool printStats = false);
     ~PerfUnwind();
 
     QString kallsymsPath() const { return m_kallsymsPath; }
@@ -230,6 +229,7 @@ public:
     QString extraLibsPath() const { return m_extraLibsPath; }
     QString appPath() const { return m_appPath; }
     QString debugPath() const { return m_debugPath; }
+    QString perfMapPath() const { return m_customPerfMapPath; }
     Stats stats() const { return m_stats; }
 
     void finalize()
@@ -278,6 +278,9 @@ private:
     // Path to kallsyms path
     QString m_kallsymsPath;
     bool m_ignoreKallsymsBuildId;
+
+    // Path to a directory containing perf-$pid.map
+    QString m_customPerfMapPath;
 
     QList<PerfRecordSample> m_sampleBuffer;
     QList<PerfRecordMmap> m_mmapBuffer;

--- a/tests/auto/perfdata/tst_perfdata.cpp
+++ b/tests/auto/perfdata/tst_perfdata.cpp
@@ -119,7 +119,7 @@ void TestPerfData::testTracingData()
     QVERIFY(output.open(QIODevice::WriteOnly));
 
     // Don't try to load any system files. They are not the same as the ones we use to report.
-    PerfUnwind unwind(&output, QStringLiteral(":/"), QString(), QString(), QString(), stats);
+    PerfUnwind unwind(&output, QStringLiteral(":/"), QString(), QString(), QString(), {}, stats);
     if (!stats) {
         QTest::ignoreMessage(QtWarningMsg,
                              QRegularExpression(QRegularExpression::escape(
@@ -209,7 +209,7 @@ void TestPerfData::testContentSize()
     QVERIFY(output.open(QIODevice::WriteOnly));
 
     // Don't try to load any system files. They are not the same as the ones we use to report.
-    PerfUnwind unwind(&output, QStringLiteral(":/"), QString(), QString(), QString(), true);
+    PerfUnwind unwind(&output, QStringLiteral(":/"), QString(), QString(), QString(), {}, true);
     process(&unwind, &input, QByteArray("0.5"));
 
     QCOMPARE(unwind.stats().numSamples, 69u);


### PR DESCRIPTION
This allows the user to define a custom perf map path. This allows him to use the data even after a reboot.