### PR TITLE
fix typo

### DIFF
--- a/app/perfdata.cpp
+++ b/app/perfdata.cpp
@@ -103,7 +103,7 @@ const char* perfEventToString(quint32 type)
     case PERF_RECORD_HEADER_FEATURE:      return "PERF_RECORD_HEADER_FEATURE";
     case PERF_RECORD_COMPRESSED:          return "PERF_RECORD_COMPRESSED";
     }
-    return "uknown type";
+    return "unknown type";
 }
 
 PerfData::ReadStatus PerfData::processEvents(QDataStream &stream)


### PR DESCRIPTION
3 additional questions:

1. Where do we get the names from? For example I currently got unknown event 82 (on Intel).
2. Wouldn't it be reasonable to cast the type to the enum, which should result in a compiler warning if there's an enum value missing?
3. Wouldn't it be reasonable to use a stringify macro here, possibly in another macro ending with

```c
switch ((enum PerfEventType)type) {
   CASE_STR_RETURN(PERF_RECORD_MMAP)
   CASE_STR_RETURN(PERF_RECORD_LOST)
   ....
}
return "unknown type";
```

This way there is no "duplication" of the string variant and using the cast to the enum.

I opt to create a PR for 2 and/or 3 (either as one or two commits) and also opt to do this together with this minor typo fix.