### PR TITLE
reduce floodding debug output

### DIFF
--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -115,7 +115,10 @@ static bool memoryRead(Dwfl *dwfl, Dwarf_Addr addr, Dwarf_Word *result, void *ar
 
     /* Check overflow. */
     if (addr + sizeof(Dwarf_Word) < addr) {
-        qDebug() << "Invalid memory read requested by dwfl" << Qt::hex << addr;
+        if (ui->lastInvalidAddr != addr) {
+            qDebug() << "Invalid memory read requested by dwfl" << Qt::hex << addr;
+            ui->lastInvalidAddr = addr;
+        }
         ui->firstGuessedFrame = ui->frames.length();
         return false;
     }

--- a/app/perfunwind.h
+++ b/app/perfunwind.h
@@ -98,13 +98,14 @@ public:
     };
 
     struct UnwindInfo {
-        UnwindInfo() : frames(0), unwind(nullptr), sample(nullptr), maxFrames(64),
-            firstGuessedFrame(-1), isInterworking(false) {}
+        UnwindInfo() : frames(0), unwind(nullptr), sample(nullptr), lastInvalidAddr(0),
+            maxFrames(64), firstGuessedFrame(-1), isInterworking(false) {}
 
         QHash<qint32, QHash<quint64, Dwarf_Word>> stackValues;
         QVector<qint32> frames;
         PerfUnwind *unwind;
         const PerfRecordSample *sample;
+        Dwarf_Addr lastInvalidAddr;
         int maxFrames;
         int firstGuessedFrame;
         bool isInterworking;


### PR DESCRIPTION
suppress debug output for invalid address passed to `memoryRead` if it is identical to the last recognized invalid one