### PR TITLE
show elfutils version in --help message

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -49,6 +49,8 @@
 #include <fcntl.h>
 #endif
 
+#include <elfutils/libdwfl.h>
+
 enum ErrorCodes {
     NoError,
     TcpSocketError,
@@ -158,7 +160,8 @@ int main(int argc, char *argv[])
     }
 
     QCommandLineParser parser;
-    parser.setApplicationDescription(QStringLiteral("Perf data parser and unwinder."));
+    auto elfutilsVersion = QString::fromUtf8(dwfl_version(nullptr));
+    parser.setApplicationDescription(QStringLiteral("Perf data parser and unwinder.\nUsing elfutils version: %1").arg(elfutilsVersion));
     parser.addHelpOption();
     parser.addVersionOption();
 


### PR DESCRIPTION
From the hotspot bug tracker:

**Is your feature request related to a problem? Please describe.**
I'm inspecting issues seen in perfparser and find it hard to go on with the appimage provided version.

One of the reasons is that appimage creation uses centos7 (I _guess_ it is still at "debuginfod only for centos8+9 state) and more important: the elfutils used, which make the biggest part of perfutils (`perf record` shows 98.5% spent in hotspot-perfparser is in `PerfRecordSample::PerfRecordSample(PerfRecordSample&&)`), is statically linked, so not well visible with `ldd` either.

**Describe the solution you'd like**
Include elfutils version in an extra line in `hotspot-perfparser` - both to make it more clear what is used and to give credits to the library that seems to do most of the actual work.
Furthermore it would be very good if the appimage debuginfo download could include the elfutils debuginfo package.

**Describe alternatives you've considered**
None.