### PR TITLE
feat: fix crash in qt6

### DIFF
--- a/app/perfdwarfdiecache.cpp
+++ b/app/perfdwarfdiecache.cpp
@@ -359,9 +359,14 @@ void CuDieRangeMapping::addSubprograms()
 
 QByteArray CuDieRangeMapping::dieName(Dwarf_Die *die)
 {
-    auto &name = m_dieNameCache[dwarf_dieoffset(die)];
-    if (name.isEmpty())
+    // in QT6 QHash is no longer iterator safe
+    // since qualifiedDieName can modify m_dieNameCache we need to insert name again
+    const auto offset = dwarf_dieoffset(die);
+    auto name = m_dieNameCache[offset];
+    if (name.isEmpty()) {
         name = demangle(qualifiedDieName(die, m_dieNameCache));
+        m_dieNameCache[offset] = name;
+    }
 
     return name;
 }


### PR DESCRIPTION
In qt6 QHash is no longer iterator safe

==138723==ERROR: AddressSanitizer: heap-use-after-free on address 0x51b000035c68 at pc 0x5d085ec696b9 bp 0x7ffe43776e00 sp 0x7ffe43776df0 READ of size 8 at 0x51b000035c68 thread T0
    #0 0x5d085ec696b8 in void qt_ptr_swap<QTypedArrayData<char> >(QTypedArrayData<char>*&, QTypedArrayData<char>*&) /usr/include/qt6/QtCore/qswap.h:31
    #1 0x5d085ec67e4f in QArrayDataPointer<char>::swap(QArrayDataPointer<char>&) /usr/include/qt6/QtCore/qarraydatapointer.h:131
    #2 0x5d085ec66e97 in QByteArray::swap(QByteArray&) /usr/include/qt6/QtCore/qbytearray.h:103
    #3 0x5d085ec66da8 in QByteArray::operator=(QByteArray&&) /usr/include/qt6/QtCore/qbytearray.h:101
    #4 0x5d085ef0ca5c in CuDieRangeMapping::dieName(Dwarf_Die*) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdwarfdiecache.cpp:364
    #5 0x5d085ee36e7c in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfsymboltable.cpp:768
    #6 0x5d085ee39eea in PerfSymbolTable::lookupFrame(unsigned long, bool, bool*) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfsymboltable.cpp:774
    #7 0x5d085ed06ec5 in frameCallback /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:541
    #8 0x75a7437f7b08 in dwfl_thread_getframes (/usr/lib/libdw.so.1+0x5bb08) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #9 0x75a7437f2eba  (/usr/lib/libdw.so.1+0x56eba) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #10 0x75a7437f3f2b in dwfl_getthreads (/usr/lib/libdw.so.1+0x57f2b) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #11 0x75a7437f7e81 in dwfl_getthread_frames (/usr/lib/libdw.so.1+0x5be81) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #12 0x5d085ed07b21 in PerfUnwind::unwindStack() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:557
    #13 0x5d085ed0d129 in PerfUnwind::analyze(PerfRecordSample const&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:744
    #14 0x5d085ed1b65f in PerfUnwind::flushEventBuffer(unsigned int) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:1115
    #15 0x5d085ed164b1 in PerfUnwind::finishedRound() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:976
    #16 0x5d085ecc2fe8 in PerfData::processEvents(QDataStream&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:243
    #17 0x5d085eccbdc2 in PerfData::doRead() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:414
    #18 0x5d085eccd6f3 in PerfData::read() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:431
    #19 0x5d085ebfa511 in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:383
    #20 0x5d085ebfd5c6 in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:452
    #21 0x5d085ec0b9b9 in call /usr/include/qt6/QtCore/qobjectdefs_impl.h:137
    #22 0x5d085ec0b121 in call<QtPrivate::List<>, void> /usr/include/qt6/QtCore/qobjectdefs_impl.h:345
    #23 0x5d085ec0aa1e in impl /usr/include/qt6/QtCore/qobjectdefs_impl.h:555
    #24 0x75a7429a3456  (/usr/lib/libQt6Core.so.6+0x1a3456) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #25 0x5d085ec33520 in PerfHeader::finished() /home/lieven/KDAB/hotspot/build-dev-asan-qt6/3rdparty/libhotspot-perfparser_autogen/6F7ISLN55V/moc_perfheader.cpp:234
    #26 0x5d085ec5d91c in PerfHeader::read() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfheader.cpp:122
    #27 0x5d085ec2f1b7 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (PerfHeader::*)()>::call(void (PerfHeader::*)(), PerfHeader*, void**) /usr/include/qt6/QtCore/qobjectdefs_impl.h:145
    #28 0x5d085ec2e24a in void QtPrivate::FunctionPointer<void (PerfHeader::*)()>::call<QtPrivate::List<>, void>(void (PerfHeader::*)(), PerfHeader*, void**) /usr/include/qt6/QtCore/qobjectdefs_impl.h:182
    #29 0x5d085ec2bf91 in QtPrivate::QCallableObject<void (PerfHeader::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /usr/include/qt6/QtCore/qobjectdefs_impl.h:553
    #30 0x75a74298d93e in QObject::event(QEvent*) (/usr/lib/libQt6Core.so.6+0x18d93e) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #31 0x75a742945bc2 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (/usr/lib/libQt6Core.so.6+0x145bc2) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #32 0x75a742945faa in QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (/usr/lib/libQt6Core.so.6+0x145faa) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #33 0x75a742babe4b  (/usr/lib/libQt6Core.so.6+0x3abe4b) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #34 0x75a740d13558  (/usr/lib/libglib-2.0.so.0+0x5d558) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #35 0x75a740d76156  (/usr/lib/libglib-2.0.so.0+0xc0156) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #36 0x75a740d12a54 in g_main_context_iteration (/usr/lib/libglib-2.0.so.0+0x5ca54) (BuildId: 7b781c8d1a6e2161838c5d8f3bd797797c132753)
    #37 0x75a742ba985c in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/libQt6Core.so.6+0x3a985c) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #38 0x75a742950105 in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (/usr/lib/libQt6Core.so.6+0x150105) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #39 0x75a74294a27c in QCoreApplication::exec() (/usr/lib/libQt6Core.so.6+0x14a27c) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #40 0x5d085ec04e44 in main /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:481
    #41 0x75a741a34e07  (/usr/lib/libc.so.6+0x25e07) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #42 0x75a741a34ecb in __libc_start_main (/usr/lib/libc.so.6+0x25ecb) (BuildId: 98b3d8e0b8c534c769cb871c438b4f8f3a8e4bf3)
    #43 0x5d085ebf4b64 in _start (/home/lieven/KDAB/hotspot/build-dev-asan-qt6/libexec/hotspot-perfparser+0x72db64) (BuildId: 580374afdfc7f3994c76369459f6848384c3c771)

0x51b000035c68 is located 1512 bytes inside of 1536-byte region [0x51b000035680,0x51b000035c80) freed by thread T0 here:
    #0 0x75a7430ff22a in operator delete[](void*) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:155
    #1 0x5d085ef2c5af in QHashPrivate::Span<QHashPrivate::Node<unsigned long, QByteArray> >::addStorage() /usr/include/qt6/QtCore/qhash.h:409
    #2 0x5d085ef240f5 in QHashPrivate::Span<QHashPrivate::Node<unsigned long, QByteArray> >::insert(unsigned long) /usr/include/qt6/QtCore/qhash.h:283
    #3 0x5d085ef1d324 in QHashPrivate::Data<QHashPrivate::Node<unsigned long, QByteArray> >::Bucket::insert() const /usr/include/qt6/QtCore/qhash.h:511
    #4 0x5d085ef18c64 in QHashPrivate::Data<QHashPrivate::Node<unsigned long, QByteArray> >::findOrInsert(unsigned long const&) /usr/include/qt6/QtCore/qhash.h:728
    #5 0x5d085ef1551a in QHash<unsigned long, QByteArray>::operator[](unsigned long const&) /usr/include/qt6/QtCore/qhash.h:1064
    #6 0x5d085ef08e30 in prependScopeNames(QByteArray&, Dwarf_Die*, QHash<unsigned long, QByteArray>&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdwarfdiecache.cpp:204
    #7 0x5d085ef0965b in qualifiedDieName(Dwarf_Die*, QHash<unsigned long, QByteArray>&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdwarfdiecache.cpp:229
    #8 0x5d085ef0c9b8 in CuDieRangeMapping::dieName(Dwarf_Die*) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdwarfdiecache.cpp:364
    #9 0x5d085ee36e7c in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfsymboltable.cpp:768
    #10 0x5d085ee39eea in PerfSymbolTable::lookupFrame(unsigned long, bool, bool*) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfsymboltable.cpp:774
    #11 0x5d085ed06ec5 in frameCallback /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:541
    #12 0x75a7437f7b08 in dwfl_thread_getframes (/usr/lib/libdw.so.1+0x5bb08) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #13 0x75a7437f2eba  (/usr/lib/libdw.so.1+0x56eba) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #14 0x75a7437f3f2b in dwfl_getthreads (/usr/lib/libdw.so.1+0x57f2b) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #15 0x75a7437f7e81 in dwfl_getthread_frames (/usr/lib/libdw.so.1+0x5be81) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #16 0x5d085ed07b21 in PerfUnwind::unwindStack() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:557
    #17 0x5d085ed0d129 in PerfUnwind::analyze(PerfRecordSample const&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:744
    #18 0x5d085ed1b65f in PerfUnwind::flushEventBuffer(unsigned int) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:1115
    #19 0x5d085ed164b1 in PerfUnwind::finishedRound() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:976
    #20 0x5d085ecc2fe8 in PerfData::processEvents(QDataStream&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:243
    #21 0x5d085eccbdc2 in PerfData::doRead() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:414
    #22 0x5d085eccd6f3 in PerfData::read() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:431
    #23 0x5d085ebfa511 in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:383
    #24 0x5d085ebfd5c6 in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:452
    #25 0x5d085ec0b9b9 in call /usr/include/qt6/QtCore/qobjectdefs_impl.h:137
    #26 0x5d085ec0b121 in call<QtPrivate::List<>, void> /usr/include/qt6/QtCore/qobjectdefs_impl.h:345
    #27 0x5d085ec0aa1e in impl /usr/include/qt6/QtCore/qobjectdefs_impl.h:555
    #28 0x75a7429a3456  (/usr/lib/libQt6Core.so.6+0x1a3456) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #29 0x5d085ec33520 in PerfHeader::finished() /home/lieven/KDAB/hotspot/build-dev-asan-qt6/3rdparty/libhotspot-perfparser_autogen/6F7ISLN55V/moc_perfheader.cpp:234

previously allocated by thread T0 here:
    #0 0x75a7430fe682 in operator new[](unsigned long) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:98
    #1 0x5d085ef2c181 in QHashPrivate::Span<QHashPrivate::Node<unsigned long, QByteArray> >::addStorage() /usr/include/qt6/QtCore/qhash.h:394
    #2 0x5d085ef240f5 in QHashPrivate::Span<QHashPrivate::Node<unsigned long, QByteArray> >::insert(unsigned long) /usr/include/qt6/QtCore/qhash.h:283
    #3 0x5d085ef1d324 in QHashPrivate::Data<QHashPrivate::Node<unsigned long, QByteArray> >::Bucket::insert() const /usr/include/qt6/QtCore/qhash.h:511
    #4 0x5d085ef18c64 in QHashPrivate::Data<QHashPrivate::Node<unsigned long, QByteArray> >::findOrInsert(unsigned long const&) /usr/include/qt6/QtCore/qhash.h:728
    #5 0x5d085ef1551a in QHash<unsigned long, QByteArray>::operator[](unsigned long const&) /usr/include/qt6/QtCore/qhash.h:1064
    #6 0x5d085ef0c883 in CuDieRangeMapping::dieName(Dwarf_Die*) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdwarfdiecache.cpp:362
    #7 0x5d085ee36e7c in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfsymboltable.cpp:768
    #8 0x5d085ee39eea in PerfSymbolTable::lookupFrame(unsigned long, bool, bool*) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfsymboltable.cpp:774
    #9 0x5d085ed06ec5 in frameCallback /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:541
    #10 0x75a7437f7b08 in dwfl_thread_getframes (/usr/lib/libdw.so.1+0x5bb08) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #11 0x75a7437f2eba  (/usr/lib/libdw.so.1+0x56eba) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #12 0x75a7437f3f2b in dwfl_getthreads (/usr/lib/libdw.so.1+0x57f2b) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #13 0x75a7437f7e81 in dwfl_getthread_frames (/usr/lib/libdw.so.1+0x5be81) (BuildId: 9b3f42d0dd4107f1cd947702b04157dad2a9069a)
    #14 0x5d085ed07b21 in PerfUnwind::unwindStack() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:557
    #15 0x5d085ed0d129 in PerfUnwind::analyze(PerfRecordSample const&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:744
    #16 0x5d085ed1b65f in PerfUnwind::flushEventBuffer(unsigned int) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:1115
    #17 0x5d085ed164b1 in PerfUnwind::finishedRound() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfunwind.cpp:976
    #18 0x5d085ecc2fe8 in PerfData::processEvents(QDataStream&) /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:243
    #19 0x5d085eccbdc2 in PerfData::doRead() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:414
    #20 0x5d085eccd6f3 in PerfData::read() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfdata.cpp:431
    #21 0x5d085ebfa511 in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:383
    #22 0x5d085ebfd5c6 in operator() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/main.cpp:452
    #23 0x5d085ec0b9b9 in call /usr/include/qt6/QtCore/qobjectdefs_impl.h:137
    #24 0x5d085ec0b121 in call<QtPrivate::List<>, void> /usr/include/qt6/QtCore/qobjectdefs_impl.h:345
    #25 0x5d085ec0aa1e in impl /usr/include/qt6/QtCore/qobjectdefs_impl.h:555
    #26 0x75a7429a3456  (/usr/lib/libQt6Core.so.6+0x1a3456) (BuildId: 2dc7cac262eec1f545dffaf6727f87faf910fb09)
    #27 0x5d085ec33520 in PerfHeader::finished() /home/lieven/KDAB/hotspot/build-dev-asan-qt6/3rdparty/libhotspot-perfparser_autogen/6F7ISLN55V/moc_perfheader.cpp:234
    #28 0x5d085ec5d91c in PerfHeader::read() /home/lieven/KDAB/hotspot/3rdparty/perfparser/app/perfheader.cpp:122
    #29 0x5d085ec2f1b7 in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (PerfHeader::*)()>::call(void (PerfHeader::*)(), PerfHeader*, void**) /usr/include/qt6/QtCore/qobjectdefs_impl.h:145

SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/qt6/QtCore/qswap.h:31 in void qt_ptr_swap<QTypedArrayData<char> >(QTypedArrayData<char>*&, QTypedArrayData<char>*&) Shadow bytes around the buggy address:
  0x51b000035980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51b000035a00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51b000035a80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51b000035b00: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x51b000035b80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x51b000035c00: fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd fd
  0x51b000035c80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x51b000035d00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x51b000035d80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x51b000035e00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x51b000035e80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==138723==ABORTING