### PR TITLE
Forward more tracepoint information to hotspot

### DIFF
--- a/app/perftracingdata.cpp
+++ b/app/perftracingdata.cpp
@@ -107,13 +107,14 @@ static void processLine(const QByteArray &line,
                         const std::function<void(const QByteArray &, const QByteArray &)> &handler)
 {
     const auto chunks = line.split('\t');
-    for (const auto &chunk : chunks) {
-        QList<QByteArray> segments = chunk.split(':');
-        if (segments.size() != 2)
+    for (const auto& chunk : chunks) {
+        auto split = chunk.indexOf(':');
+        if (split == -1) {
             continue;
+        }
 
-        QByteArray name = segments[0].toLower();
-        QByteArray value = segments[1].trimmed();
+        auto name = chunk.left(split).toLower().trimmed();
+        auto value = chunk.mid(split + 1).trimmed();
         if (value.endsWith(';'))
             value.chop(1);
         handler(name, value);
@@ -240,6 +241,8 @@ bool PerfTracingData::readEventFormats(QDataStream &stream, const QByteArray &sy
                         seenId = true;
                     } else if (name == "format") {
                         stage = CommonFields;
+                    } else if (name == "print fmt") {
+                        event.format = value;
                     }
                 });
             }

--- a/app/perftracingdata.h
+++ b/app/perftracingdata.h
@@ -66,6 +66,7 @@ struct EventFormat
     QVector<FormatField> commonFields;
     QVector<FormatField> fields;
     quint32 flags = 0;
+    QByteArray format;
 };
 
 class PerfTracingData

--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -428,7 +428,7 @@ void PerfUnwind::sendEventFormat(qint32 id, const EventFormat &format)
 
     QByteArray buffer;
     QDataStream(&buffer, QIODevice::WriteOnly) << static_cast<quint8>(TracePointFormat) << id
-                                               << systemId << nameId << format.flags;
+                                               << systemId << nameId << format.flags << resolveString(format.format);
     sendBuffer(buffer);
 }
 
@@ -809,13 +809,12 @@ void PerfUnwind::analyze(const PerfRecordSample &sample)
 
     if (type == TracePointSample) {
         QHash<qint32, QVariant> traceData;
-        const QByteArray &data = sample.rawData();
-        const EventFormat &format = m_tracingData.eventFormat(eventFormatId);
-        for (const FormatField &field : format.fields) {
-            traceData[lookupString(field.name)]
-                    = readTraceData(data, field, m_byteOrder != QSysInfo::ByteOrder);
+        const QByteArray& data = sample.rawData();
+        const EventFormat& format = m_tracingData.eventFormat(eventFormatId);
+        for (const FormatField& field : format.fields) {
+            traceData[lookupString(field.name)] = readTraceData(data, field, m_byteOrder != QSysInfo::ByteOrder);
         }
-        stream << traceData;
+        stream << eventFormatId << traceData;
     }
 
     sendBuffer(buffer);


### PR DESCRIPTION
This patch forwards the tracepoint formatstring and the event format id for tracepoints to hotspot.