### PR TITLE
test: update tracepoint format

### DIFF
--- a/tests/auto/shared/perfparsertestclient.cpp
+++ b/tests/auto/shared/perfparsertestclient.cpp
@@ -162,7 +162,8 @@ void PerfParserTestClient::extractTrace(QIODevice *device)
                 checkAttribute(value.first);
 
             if (eventType == TracePointSample) {
-                stream >> sample.tracePointData;
+				qint32 formatId;
+                stream >> formatId >> sample.tracePointData;
                 for (auto it = sample.tracePointData.constBegin(),
                      end = sample.tracePointData.constEnd();
                      it != end; ++it) {
@@ -183,9 +184,10 @@ void PerfParserTestClient::extractTrace(QIODevice *device)
             qint32 id;
             TracePointFormatEvent tracePointFormat;
             stream >> id >> tracePointFormat.system >> tracePointFormat.name
-                   >> tracePointFormat.flags;
+                   >> tracePointFormat.flags >> tracePointFormat.format;
             checkString(tracePointFormat.system);
             checkString(tracePointFormat.name);
+			checkString(tracePointFormat.format);
             QVERIFY(!m_tracePointFormats.contains(id));
             m_tracePointFormats.insert(id, tracePointFormat);
             break;

--- a/tests/auto/shared/perfparsertestclient.h
+++ b/tests/auto/shared/perfparsertestclient.h
@@ -93,6 +93,7 @@ public:
         qint32 system = -1;
         qint32 name = -1;
         quint32 flags = 0;
+        qint32 format = -1;
     };
 
     // Repeated here, as we want to check against accidental changes in enum values.


### PR DESCRIPTION
The format has changed to provide more info to hotspot but the tests still expected the old format. This patch updates the patch to use the new format.