### PR TITLE
fix: exclude mapping symbols from symbol table

### DIFF
--- a/app/perfaddresscache.cpp
+++ b/app/perfaddresscache.cpp
@@ -121,7 +121,22 @@ void PerfAddressCache::setSymbolCache(const QByteArray &filePath, SymbolCache ca
     m_symbolCache[filePath] = cache;
 }
 
-PerfAddressCache::SymbolCache PerfAddressCache::extractSymbols(Dwfl_Module *module, quint64 elfStart, bool isArmArch)
+static bool isMappingSymbol(const char* sym, PerfRegisterInfo::Architecture arch)
+{
+    switch (arch) {
+        case PerfRegisterInfo::ARCH_AARCH64:
+            return strncmp(sym, "$x", 2) == 0;
+        case PerfRegisterInfo::ARCH_ARM:
+            return strncmp(sym, "$a", 2) == 0 || strncmp(sym, "$t", 2) == 0;
+        // TODO: Add cases for RISC-V and CSKY when supported, see:
+        // https://github.com/llvm/llvm-project/blob/de93f7ed0d615060735ad15e720f2497ed1d2468/llvm/include/llvm/Object/ELFObjectFile.h#L817
+        default:
+            return false;
+    }
+}
+
+PerfAddressCache::SymbolCache PerfAddressCache::extractSymbols(Dwfl_Module* module, quint64 elfStart,
+                                                               PerfRegisterInfo::Architecture arch)
 {
     PerfAddressCache::SymbolCache cache;
 
@@ -130,8 +145,8 @@ PerfAddressCache::SymbolCache PerfAddressCache::extractSymbols(Dwfl_Module *modu
         GElf_Sym sym;
         GElf_Addr symAddr;
         const auto symbol = dwfl_module_getsym_info(module, i, &sym, &symAddr, nullptr, nullptr, nullptr);
-        if (symbol) {
-            const quint64 start = alignedAddress(sym.st_value, isArmArch);
+        if (symbol && !isMappingSymbol(symbol, arch)) {
+            const quint64 start = alignedAddress(sym.st_value, arch == PerfRegisterInfo::ARCH_ARM);
             cache.append({symAddr - elfStart, start, sym.st_size, symbol});
         }
     }

--- a/app/perfaddresscache.h
+++ b/app/perfaddresscache.h
@@ -24,6 +24,7 @@
 #include <QVector>
 
 #include "perfelfmap.h"
+#include "perfregisterinfo.h"
 
 #include <libdwfl.h>
 
@@ -89,7 +90,7 @@ public:
     SymbolCacheEntry findSymbol(const QByteArray &filePath, quint64 relAddr);
 
     /// extract all symbols in @p module into a structure suitable to be passed to @p setSymbols
-    static SymbolCache extractSymbols(Dwfl_Module *module, quint64 elfStart, bool isArmArch);
+    static SymbolCache extractSymbols(Dwfl_Module *module, quint64 elfStart, PerfRegisterInfo::Architecture arch);
 
 private:
     QHash<QByteArray, OffsetAddressCache> m_cache;

--- a/app/perfsymboltable.cpp
+++ b/app/perfsymboltable.cpp
@@ -715,7 +715,8 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
 
     Dwfl_Module *mod = module(ip, elf);
 
-    const bool isArmArch = (m_unwind->architecture() == PerfRegisterInfo::ARCH_ARM);
+    const auto arch = m_unwind->architecture();
+    const bool isArmArch = (arch == PerfRegisterInfo::ARCH_ARM);
     PerfUnwind::Location addressLocation(PerfAddressCache::symbolAddress(ip, isArmArch), 0, -1, m_pid);
     PerfUnwind::Location functionLocation(addressLocation);
 
@@ -730,7 +731,7 @@ int PerfSymbolTable::lookupFrame(Dwarf_Addr ip, bool isKernel,
             // cache all symbols in a sorted lookup table and demangle them on-demand
             // note that the symbols within the symtab aren't necessarily sorted,
             // which makes searching repeatedly via dwfl_module_addrinfo potentially very slow
-            addressCache->setSymbolCache(elf.originalPath, PerfAddressCache::extractSymbols(mod, elfStart, isArmArch));
+            addressCache->setSymbolCache(elf.originalPath, PerfAddressCache::extractSymbols(mod, elfStart, arch));
         }
 
         auto cachedAddrInfo = addressCache->findSymbol(elf.originalPath, addressLocation.address - elfStart);


### PR DESCRIPTION
Mapping symbols are used on arm, aarch64 and some other architectures to mark code and data. They are not relevant to hotspot so exclude them from the symbol table. Without this I was sometimes seeing mapping symbols appear in flame graphs on aarch64.