### PR TITLE
fix: subtract 1 from call chain addresses other than the first one

### DIFF
--- a/app/perfunwind.cpp
+++ b/app/perfunwind.cpp
@@ -623,6 +623,12 @@ void PerfUnwind::resolveCallchain()
             if (hasBranchStack && !isKernel)
                 break;
 
+            // For stack frames other than the first one, ip is a return address, so it points to the instruction after
+            // the call instruction. Therefore, subtract 1 from the return address so that it gets correctly attributed
+            // to the call instruction.
+            if (addedUserFrames)
+                --ip;
+
             if (!reportIp(ip))
                 return;
 


### PR DESCRIPTION
For stack frames other than the first one, ip is a return address, so it points to the instruction after the call instruction. By using the return address as is, we were incorrectly attributing these call chain samples to the instruction following the call. Therefore, subtract 1 from the return address so that it gets correctly attributed to the call instruction.